### PR TITLE
Spring Boot Web3jSampleController

### DIFF
--- a/spring-boot/build.gradle
+++ b/spring-boot/build.gradle
@@ -24,7 +24,8 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    compile 'org.web3j:web3j-spring-boot-starter:1.0.0'
+    compile 'org.web3j:web3j-spring-boot-starter:1.0.0',
+            'org.springframework.boot:spring-boot-starter-web:2.7.3'
     testCompile 'junit:junit',
             'org.springframework.boot:spring-boot-starter-test:1.5.1.RELEASE'
 }

--- a/spring-boot/src/main/java/org/web3j/examples/Web3jSampleRestController.java
+++ b/spring-boot/src/main/java/org/web3j/examples/Web3jSampleRestController.java
@@ -1,0 +1,30 @@
+package org.web3j.examples;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/client")
+public class Web3jSampleRestController {
+
+    private final Web3jSampleService web3jSampleService;
+
+    public Web3jSampleRestController(final Web3jSampleService web3jSampleService) {
+        this.web3jSampleService = web3jSampleService;
+    }
+
+    @GetMapping("/version")
+    @ResponseBody
+    public String getClientVersion() throws IOException {
+        return web3jSampleService.getClientVersion();
+    }
+
+    @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler({IOException.class})
+    public String ioError() {
+        return "Internal I/O error.";
+    }
+
+}

--- a/spring-boot/src/main/java/org/web3j/examples/Web3jSampleService.java
+++ b/spring-boot/src/main/java/org/web3j/examples/Web3jSampleService.java
@@ -2,7 +2,6 @@ package org.web3j.examples;
 
 import java.io.IOException;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import org.web3j.protocol.Web3j;
@@ -14,8 +13,11 @@ import org.web3j.protocol.core.methods.response.Web3ClientVersion;
 @Service
 public class Web3jSampleService {
 
-    @Autowired
-    private Web3j web3j;
+    private final Web3j web3j;
+
+    public Web3jSampleService(final Web3j web3j) {
+        this.web3j = web3j;
+    }
 
     public String getClientVersion() throws IOException {
         Web3ClientVersion web3ClientVersion = web3j.web3ClientVersion().send();

--- a/spring-boot/src/test/java/org/web3j/examples/SpringBootWeb3jSampleApplicationTest.java
+++ b/spring-boot/src/test/java/org/web3j/examples/SpringBootWeb3jSampleApplicationTest.java
@@ -1,13 +1,14 @@
 package org.web3j.examples;
 
-import java.io.IOException;
-
 import org.apache.http.conn.HttpHostConnectException;
+import org.assertj.core.api.Java6Assertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -16,7 +17,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SpringBootWeb3jSampleApplicationTest {
 
     @Autowired
+    private Web3jSampleRestController web3JSampleRestController;
+
+    @Autowired
     private Web3jSampleService web3jSampleService;
+
+    @Test
+    public void contextLoads() {
+        assertThat(web3JSampleRestController).isNotNull();
+    }
 
     // This test will only run if you provide a real Ethereum client for web3j to connect to
     @Test(expected = HttpHostConnectException.class)

--- a/spring-boot/src/test/java/org/web3j/examples/Web3JSampleRestControllerTest.java
+++ b/spring-boot/src/test/java/org/web3j/examples/Web3JSampleRestControllerTest.java
@@ -1,0 +1,71 @@
+package org.web3j.examples;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(MockitoJUnitRunner.class)
+public class Web3JSampleRestControllerTest {
+
+    private MockMvc mockMvc;
+    private final Web3jSampleService web3jSampleService = Mockito.mock(Web3jSampleService.class);
+    private final Web3jSampleRestController web3JSampleRestController = new Web3jSampleRestController(web3jSampleService);
+
+    @Before
+    public void initMockMvc() {
+        this.mockMvc = MockMvcBuilders.standaloneSetup(web3JSampleRestController)
+                .setControllerAdvice(ExceptionHandler.class)
+                .build();
+    }
+
+    @Test
+    public void testReturnClientVersion() throws Exception {
+        final String clientVersion = "Ganache/v7.4.3/EthereumJS TestRPC/v7.4.3/ethereum-js";
+        Mockito.when(web3jSampleService.getClientVersion()).thenReturn(clientVersion);
+        mockMvc.perform(get("/client/version"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(clientVersion));
+    }
+
+    @Test
+    public void testHandleIoException() throws Exception {
+        Mockito.when(web3jSampleService.getClientVersion()).thenThrow(new IOException());
+        mockMvc.perform(get("/client/version"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(content().string("Internal I/O error."));
+    }
+
+    @Test
+    public void testBasePath() {
+        final RequestMapping annotation = Web3jSampleRestController.class.getAnnotation(RequestMapping.class);
+        assertThat(annotation).isNotNull();
+        assertThat(annotation.value()).containsExactly("/client");
+    }
+
+    @Test
+    public void testVersionPath() throws NoSuchMethodException {
+        final Class<Web3jSampleRestController> c = Web3jSampleRestController.class;
+        final Method getVersionMethod = c.getMethod("getClientVersion");
+        assertThat(getVersionMethod).isNotNull();
+
+        final GetMapping annotation = getVersionMethod.getAnnotation(GetMapping.class);
+        assertThat(annotation).isNotNull();
+        assertThat(annotation.value()).containsExactly("/version");
+    }
+
+}


### PR DESCRIPTION
### What does this PR do?

Creates a `Web3jSampleRestController`, which injects the already existing `Web3jSampleService`, to be able to retrieve the client version by doing:
```http
GET /client/version
```

Further, it refactors some field-based DI to constructor-based DI, to adhere to Spring best practices. And it adds a dependency on `spring-boot-starter-web` to be able to run the web service.

### Where should the reviewer start?

Start at `Web3jSampleRestControllerTest` as it covers the expected behavior. To test the changes manually, run an Ethereum client (e.g. Ganache) and go to http://localhost:8080/client/version

![Screenshot from 2022-09-18 21-39-37](https://user-images.githubusercontent.com/72470369/190925488-2319a7a2-ddec-4124-bb57-56b3141010cf.png)

### Why is it needed?

Because it allows the user to start the Spring Boot application with an example REST endpoint, without having to write code; while keeping the example minimal
